### PR TITLE
Code to calculate effect of pension cuts on current salary. 

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -445,7 +445,6 @@ retirement_date <- function(dob)
 #' @return relevant row from output of \code{pension_calculation}
 pension_summary <- function(benefits, dob)
 {
-  print("calling summary")
   retirementYearIdx <- which(benefits$year == lubridate::year(retirement_date(dob)))
   incomeWorkingYears <- benefits$income[1:retirementYearIdx]
 


### PR DESCRIPTION
This code calculates what percentage of current and future earnings would need to be invested in order to match the DB pot total or to top-up the DB to match the TPS.  It also contains code that calculates the value if a constant pound amount was invested each year.  But that is not exposed to the user because it is not commonly a realistic scenario for an individual.  

This code update is paired with a pull-request to USSpensions-shiny to display these calculations.
